### PR TITLE
updating django file manager to work with django 3.x

### DIFF
--- a/filemanager/templates/filemanager/filemanager_base.html
+++ b/filemanager/templates/filemanager/filemanager_base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block head %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/filemanager/templates/filemanager/filemanager_upload.html
+++ b/filemanager/templates/filemanager/filemanager_upload.html
@@ -1,6 +1,6 @@
 {% extends "filemanager/filemanager_base.html" %}
 
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block content %}
 {% include "filemanager/filemanager_breadcrumbs.html" %}

--- a/filemanager/templates/filemanager/upload_modal.html
+++ b/filemanager/templates/filemanager/upload_modal.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 <div class="modal fade" id="upload-modal" role="dialog">
     <div class="modal-dialog">


### PR DESCRIPTION
Hey @rameezarshad ! Here is a quick update so that filemanager works with newer Django. If you haven't done it yet, it might make sense to have earlier releases available (and a note in the README indicating the Django versions supported). If you can share that with me I'd be happy to add to this PR. This will close #1.

Signed-off-by: vsoch <vsochat@stanford.edu>